### PR TITLE
Prevent fatal error if Vault object not created

### DIFF
--- a/app/code/local/Litle/CreditCard/Model/PaymentLogic.php
+++ b/app/code/local/Litle/CreditCard/Model/PaymentLogic.php
@@ -449,7 +449,9 @@ class Litle_CreditCard_Model_PaymentLogic extends Mage_Payment_Model_Method_Cc
 					$this->getUpdater($litleResponse, 'tokenResponse', 'litleToken'),
 					$this->getUpdater($litleResponse, 'tokenResponse', 'bin'));
 
-			$this->getInfoInstance()->setAdditionalInformation('vault_id', $vault->getId());
+			if ($vault) {
+				$this->getInfoInstance()->setAdditionalInformation('vault_id', $vault->getId());
+			}
 		}
 	}
 


### PR DESCRIPTION
Rare circumstances could cause setTokenFromPayment() to not return a vault object, which causes $vault->getId() to issue a fatal error.
